### PR TITLE
Parse escaped chars

### DIFF
--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -602,9 +602,9 @@ open class JSON {
             .replacingOccurrences(of: "\\t", with: "\t", range: nil)
             .replacingOccurrences(of: "\\r", with: "\r", range: nil)
             .replacingOccurrences(of: "\\\"", with: "\"", range: nil)
-        if let regex = try? NSRegularExpression(pattern: "\\\\u[0-9A-Fa-f]{4}") {
+        if let hexEncodedUnicodeCharRegex = try? NSRegularExpression(pattern: "\\\\u[0-9A-Fa-f]{4}") {
             let parsedStringNs = parsedString as NSString
-            for match in regex.matches(in: parsedString, range: NSMakeRange(0, parsedStringNs.length)) {
+            for match in hexEncodedUnicodeCharRegex.matches(in: parsedString, range: NSMakeRange(0, parsedStringNs.length)) {
                 let matchString = parsedStringNs.substring(with: match.range) as String
                 let matchStringHex = matchString.suffix(4)
                 var replaceData = Data()

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -599,7 +599,9 @@ open class JSON {
         let startingIndex = index
         
         while index != jsonString.endIndex {
-            if jsonString[index] == "\\" {
+            
+            if jsonString[index] == "\\"
+                && jsonString[jsonString.index(before: index)] != "\\" {
                 index = jsonString.index(after: index)
                 
                 if jsonString[index] == "\"" {

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -80,7 +80,7 @@ public extension Value {
      - parameter key: key for value
      - returns: value for key. Also returns nil if it is not a key/value structure
      */
-    subscript(key: String) -> Value? {
+    public subscript(key: String) -> Value? {
         get {
             return (self as? [JSON.ObjectElement])?.reduce(nil, { (result, element) -> Value? in
                 guard result == nil else { return result }
@@ -94,7 +94,7 @@ public extension Value {
      - parameter index: index to retrieve
      - returns: value if index is valid and the subject is an array of `JSON.ArrayElement`s
      */
-    subscript(index: Int) -> Value? {
+    public subscript(index: Int) -> Value? {
         get {
             guard let elementArray = self as? [JSON.ArrayElement],
                 index >= 0,
@@ -106,22 +106,13 @@ public extension Value {
     }
     
     /// Get all keys in the key/value set, returns nil if the array is not keys/values.
-    var keys: [String]? {
+    public var keys: [String]? {
         return (self as? [JSON.ObjectElement])?.compactMap { $0.key }
     }
     
     /// Get all values in the current structure
-    var values: [Value]? {
+    public var values: [Value]? {
         return (self as? [JSON.ArrayElement])?.map { $0.value } ?? (self as? [JSON.ObjectElement])?.map { $0.value }
-    }
-    
-    func asInt() -> Int {
-        if let value = self as? Int {
-            return value
-        } else if let value = self as? String {
-            return Int(value) ?? -1
-        }
-        return -1
     }
 }
 

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -597,7 +597,7 @@ open class JSON {
         }
         
         var parsedString = String(jsonString[startingIndex ..< index])
-        parsedString = parsedString.replacingOccurrences(of: "\\\\", with: "\\", range: nil)
+            .replacingOccurrences(of: "\\\\", with: "\\", range: nil)
             .replacingOccurrences(of: "\\n", with: "\n", range: nil)
             .replacingOccurrences(of: "\\t", with: "\t", range: nil)
             .replacingOccurrences(of: "\\r", with: "\r", range: nil)

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -596,7 +596,29 @@ open class JSON {
             }
         }
         
-        let parsedString = String(jsonString[startingIndex ..< index])
+        var parsedString = String(jsonString[startingIndex ..< index])
+        parsedString = parsedString.replacingOccurrences(of: "\\\\", with: "\\", range: nil)
+            .replacingOccurrences(of: "\\n", with: "\n", range: nil)
+            .replacingOccurrences(of: "\\t", with: "\t", range: nil)
+            .replacingOccurrences(of: "\\r", with: "\r", range: nil)
+            .replacingOccurrences(of: "\\\"", with: "\"", range: nil)
+        if let regex = try? NSRegularExpression(pattern: "\\\\u[0-9A-Fa-f]{4}") {
+            let parsedStringNs = parsedString as NSString
+            for match in regex.matches(in: parsedString, range: NSMakeRange(0, parsedStringNs.length)) {
+                let matchString = parsedStringNs.substring(with: match.range) as String
+                let matchStringHex = matchString.suffix(4)
+                var replaceData = Data()
+                if let byte = UInt8(matchStringHex.prefix(2), radix: 16), byte > 0 {
+                    replaceData.append(contentsOf: [byte])
+                }
+                if let byte = UInt8(matchStringHex.suffix(2), radix: 16), byte > 0 {
+                    replaceData.append(contentsOf: [byte])
+                }
+                if let replacementString = String(data: replaceData, encoding: .isoLatin1) {
+                    parsedString = parsedString.replacingOccurrences(of: matchString, with: replacementString)
+                }
+            }
+        }
         
         guard index != jsonString.endIndex else {
             index = startingIndex

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -599,12 +599,9 @@ open class JSON {
         let startingIndex = index
         
         while index != jsonString.endIndex {
-            
-            if jsonString[index] == "\\"
-                && jsonString[jsonString.index(before: index)] != "\\" {
+            if jsonString[index] == "\\" {
                 index = jsonString.index(after: index)
-                
-                if jsonString[index] == "\"" {
+                if jsonString[index] == "\"" || jsonString[index] == "\\" {
                     index = jsonString.index(after: index)
                 } else {
                     continue

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -80,7 +80,7 @@ public extension Value {
      - parameter key: key for value
      - returns: value for key. Also returns nil if it is not a key/value structure
      */
-    public subscript(key: String) -> Value? {
+    subscript(key: String) -> Value? {
         get {
             return (self as? [JSON.ObjectElement])?.reduce(nil, { (result, element) -> Value? in
                 guard result == nil else { return result }
@@ -94,7 +94,7 @@ public extension Value {
      - parameter index: index to retrieve
      - returns: value if index is valid and the subject is an array of `JSON.ArrayElement`s
      */
-    public subscript(index: Int) -> Value? {
+    subscript(index: Int) -> Value? {
         get {
             guard let elementArray = self as? [JSON.ArrayElement],
                 index >= 0,
@@ -106,13 +106,22 @@ public extension Value {
     }
     
     /// Get all keys in the key/value set, returns nil if the array is not keys/values.
-    public var keys: [String]? {
+    var keys: [String]? {
         return (self as? [JSON.ObjectElement])?.compactMap { $0.key }
     }
     
     /// Get all values in the current structure
-    public var values: [Value]? {
+    var values: [Value]? {
         return (self as? [JSON.ArrayElement])?.map { $0.value } ?? (self as? [JSON.ObjectElement])?.map { $0.value }
+    }
+    
+    func asInt() -> Int {
+        if let value = self as? Int {
+            return value
+        } else if let value = self as? String {
+            return Int(value) ?? -1
+        }
+        return -1
     }
 }
 
@@ -201,6 +210,15 @@ open class JSON {
         let key: String
         /// Object element value
         let value: Value & JSONStringRepresentable
+    }
+    
+    public static func parse(data: Data) throws -> Value {
+        let str = String(data: data, encoding: .utf8)
+        if let str = str {
+            return try JSON.parse(string: str)
+        } else {
+            throw SerializationError.invalidJSON
+        }
     }
     
     /**

--- a/Source/JSON.swift
+++ b/Source/JSON.swift
@@ -597,6 +597,7 @@ open class JSON {
         }
         
         var parsedString = String(jsonString[startingIndex ..< index])
+            .replacingOccurrences(of: "\\/", with: "/", range: nil)
             .replacingOccurrences(of: "\\\\", with: "\\", range: nil)
             .replacingOccurrences(of: "\\n", with: "\n", range: nil)
             .replacingOccurrences(of: "\\t", with: "\t", range: nil)

--- a/Tests/StringTests.swift
+++ b/Tests/StringTests.swift
@@ -47,7 +47,18 @@ class StringTests: TisanderTest {
         var json: Value
         do { json = try JSON.parse(string: input) } catch let e { XCTFail((e as? SerializationError)?.rawValue ?? "Unknown exception"); return }
         
-        XCTAssertEqual(json[0] as? String, "\\\"")
+        XCTAssertEqual(json[0] as? String, "\"")
+    }
+    
+    func testEscapedCharsString() {
+        let input = """
+["\\n", "\\u00fc"]
+"""
+        var json: Value
+        do { json = try JSON.parse(string: input) } catch let e { XCTFail((e as? SerializationError)?.rawValue ?? "Unknown exception"); return }
+        
+        XCTAssertEqual(json[0] as? String, "\n")
+        XCTAssertEqual(json[1] as? String, "ü")
     }
     
 //    func testEscapedSlashString() {

--- a/Tests/StringTests.swift
+++ b/Tests/StringTests.swift
@@ -42,7 +42,7 @@ class StringTests: TisanderTest {
     
     func testEscapedCharsString() {
         let input = """
-["\\n", "\\t", "\\r", "\\\"", "\\u00fc"]
+["\\n", "\\t", "\\r", "\\\"", "\\u00fc", "\\\\"]
 """
         var json: Value
         do { json = try JSON.parse(string: input) } catch let e { XCTFail((e as? SerializationError)?.rawValue ?? "Unknown exception"); return }
@@ -52,16 +52,18 @@ class StringTests: TisanderTest {
         XCTAssertEqual(json[2] as? String, "\r")
         XCTAssertEqual(json[3] as? String, "\"")
         XCTAssertEqual(json[4] as? String, "ü")
+        XCTAssertEqual(json[5] as? String, "\\")
     }
     
-//    func testEscapedSlashString() {
-//        let input = """
-//["\\\\"]
-//"""
-//        do { json = try JSON.parse(string: input) } catch let e { XCTFail((e as? SerializationError)?.rawValue ?? "Unknown exception"); return }
-//
-//        XCTAssertEqual(json[0] as? String, nil)
-//    }
+    func testEscapedSlashString() {
+        // invalid JSON ["a\b\"] should throw SerializationError.unterminatedString
+        let input = """
+["a\\b\\"]
+"""
+        XCTAssertThrowsError(try JSON.parse(string: input)) { error in
+            XCTAssertEqual(error as! SerializationError, SerializationError.unterminatedString)
+        }
+    }
     
     func testUnterminatedString() {
         let input = """

--- a/Tests/StringTests.swift
+++ b/Tests/StringTests.swift
@@ -40,25 +40,18 @@ class StringTests: TisanderTest {
         XCTAssertEqual(json[0] as? String, "\\a")
     }
     
-    func testEscapedQuoteString() {
-        let input = """
-["\\\""]
-"""
-        var json: Value
-        do { json = try JSON.parse(string: input) } catch let e { XCTFail((e as? SerializationError)?.rawValue ?? "Unknown exception"); return }
-        
-        XCTAssertEqual(json[0] as? String, "\"")
-    }
-    
     func testEscapedCharsString() {
         let input = """
-["\\n", "\\u00fc"]
+["\\n", "\\t", "\\r", "\\\"", "\\u00fc"]
 """
         var json: Value
         do { json = try JSON.parse(string: input) } catch let e { XCTFail((e as? SerializationError)?.rawValue ?? "Unknown exception"); return }
         
         XCTAssertEqual(json[0] as? String, "\n")
-        XCTAssertEqual(json[1] as? String, "ü")
+        XCTAssertEqual(json[1] as? String, "\t")
+        XCTAssertEqual(json[2] as? String, "\r")
+        XCTAssertEqual(json[3] as? String, "\"")
+        XCTAssertEqual(json[4] as? String, "ü")
     }
     
 //    func testEscapedSlashString() {

--- a/Tests/StringTests.swift
+++ b/Tests/StringTests.swift
@@ -55,10 +55,20 @@ class StringTests: TisanderTest {
         XCTAssertEqual(json[5] as? String, "\\")
     }
     
-    func testEscapedSlashString() {
+    func testUnterminatedStringError() {
         // invalid JSON ["a\b\"] should throw SerializationError.unterminatedString
         let input = """
 ["a\\b\\"]
+"""
+        XCTAssertThrowsError(try JSON.parse(string: input)) { error in
+            XCTAssertEqual(error as! SerializationError, SerializationError.unterminatedString)
+        }
+    }
+    
+    func testUnterminatedStringError2() {
+        // invalid JSON ["a\\\"] should throw SerializationError.unterminatedString
+        let input = """
+["a\\\\\\"]
 """
         XCTAssertThrowsError(try JSON.parse(string: input)) { error in
             XCTAssertEqual(error as! SerializationError, SerializationError.unterminatedString)


### PR DESCRIPTION
Hi! First of all, thanks for this library!

I noticed that it does not parse escaped chars like `\n` or `\u00fc` (ü), see [here](https://stackoverflow.com/questions/19176024/how-to-escape-special-characters-in-building-a-json-string#answer-27516892).

This change adds support for those escaped values.